### PR TITLE
Add proper Unicode handling

### DIFF
--- a/IrcDotRT/IrcClient.cs
+++ b/IrcDotRT/IrcClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -1843,11 +1843,11 @@ namespace IrcDotRT
                     while (reader.UnconsumedBufferLength > 0)
                     {
                         bool breakLoop = false;
-                        char readChar;
+                        byte readChar;
                         do
                         {
                             if (reader.UnconsumedBufferLength > 0)
-                                readChar = (char)reader.ReadByte();
+                                readChar = reader.ReadByte();
                             else
                             {
                                 breakLoop = true;

--- a/IrcDotRT/SafeLineReader.cs
+++ b/IrcDotRT/SafeLineReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,6 +12,8 @@ namespace IrcDotRT
         // Current incomplete line;
         private string currentLine;
 
+        private List<byte> bytesList = new List<byte>();
+
         private bool endOfLine = false;
 
         private char PreviousCharacter()
@@ -19,10 +21,13 @@ namespace IrcDotRT
             return currentLine[currentLine.Length - 1];
         }
 
-        public bool Add(char character)
+        public bool Add(byte b)
         {
+            char character = (char)b;
             if (character == '\n' && PreviousCharacter() == '\r')
                 endOfLine = true;
+
+            bytesList.Add(b);
 
             currentLine += character;
 
@@ -31,10 +36,13 @@ namespace IrcDotRT
 
         public string FlushLine()
         {
+            var buffer = bytesList.ToArray();
+            currentLine = System.Text.Encoding.UTF8.GetString(buffer, 0, buffer.Length);
             string tempLine = currentLine.Substring(0, currentLine.Length - 2);
 
             currentLine = String.Empty;
             endOfLine = false;
+            bytesList.Clear();
 
             return tempLine;
         }


### PR DESCRIPTION
I figured out how to fix issue #1 by storing the raw bytes as a byte list and using `System.Text.Encoding.UTF8.GetString(buffer, 0, buffer.Length);` to read this byte list.

Although I'm not actively using this library (I'm instead using the line reading in my own application) this addition may benefit others.
